### PR TITLE
BugFix "ws://" required in Websocket URL

### DIFF
--- a/imports/api/apollo/server/createApolloSubscriptionServer.js
+++ b/imports/api/apollo/server/createApolloSubscriptionServer.js
@@ -5,7 +5,7 @@ const WS_URL = process.env.WS_URL || `localhost:4005`;
 const wsUrlParts = WS_URL.split(':');
 const WS_PORT = wsUrlParts[wsUrlParts.length - 1];
 
-Meteor.settings.public.WS_URL = process.env.WS_URL || `localhost:4005`;
+Meteor.settings.public.WS_URL = process.env.WS_URL || `ws://localhost:4005`;
 
 function createApolloSubscriptionServer({ subscriptionManager }) {
     const httpServer = createServer((request, response) => {


### PR DESCRIPTION
Correction for the "Uncaught DOMException: Failed to construct 'WebSocket': The URL's scheme must be either 'ws' or 'wss'. 'localhost' is not allowed" received in the browser.  Thank you.